### PR TITLE
Clarify code for using MMM-GoogleCalendar module

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,18 @@ symbol: ['brands google-drive', 'solid calendar'],
 ### Compatible with `randomBrainstormer/MMM-GoogleCalendar`
 ```js
 preProcessor: (e) => {
-  e.startDate = new Date(e.start?.date || e.start?.dateTime).valueOf()
-  e.endDate = new Date(e.end?.date || e.end?.dateTime).valueOf()
+  if (e.start?.dateTime) {
+          e.startDate = new Date(e.start.dateTime).valueOf()
+  } else if (e.start?.date) {
+          e.startDate = new Date(`${e.start.date}T00:00:00`).valueOf()
+  }
+  
+  if (e.end?.dateTime) {
+          e.endDate = new Date(e.end.dateTime).valueOf()
+  } else if (e.end?.date) {
+          e.endDate = new Date(`${e.end.date}T00:00:00`).valueOf()
+  }
+  
   e.title = e.summary
   e.fullDayEvent = (e.start?.date) ? true : false
   return e


### PR DESCRIPTION
The original provided code would make multi-day events show a day early if you are in a negative UTC offset timezone.  Adding the T00:00:00 ensures that they start at midnight local time, not X hours before.