### PR TITLE
fix popover support check

### DIFF
--- a/MMM-CalendarExt3.js
+++ b/MMM-CalendarExt3.js
@@ -2,7 +2,7 @@
 /* x-eslint-disable @stylistic/linebreak-style, @stylistic/semi, @stylistic/indent */
 /* eslint-disable no-undef, no-unused-vars */
 
-const popoverSupported = (typeof HTMLElement !== "undefined") ? Object.hasOwn(HTMLElement, "popover") : false
+const popoverSupported = HTMLElement.prototype.hasOwnProperty("popover")
 if (!popoverSupported) console.info("This browser doesn't support popover yet. Update your system.")
 const animationSupported = (typeof window !== "undefined" && window?.mmVersion) ? +(window.mmVersion.split(".").join("")) >= 2250 : false
 


### PR DESCRIPTION
on my browsers (firefox, chrome, chromium and chrome based edge) the popover detection didn't work anymore since #170. So i changed back to the old variant of checking.