### PR TITLE
feat: new option `showHeader`

### DIFF
--- a/MMM-CalendarExt3.js
+++ b/MMM-CalendarExt3.js
@@ -82,7 +82,7 @@ Module.register("MMM-CalendarExt3", {
     skipDuplicated: true,
     monthIndex: 0,
     referenceDate: null,
-
+    showHeader: true, 
     customHeader: false // true or function
   },
 
@@ -755,7 +755,7 @@ Module.register("MMM-CalendarExt3", {
       config: options,
       range: [boc, eoc]
     })
-    makeDayHeaderDom(dom, options, { boc, eoc })
+    if (options.showHeader) makeDayHeaderDom(dom, options, { boc, eoc })
     makeWeekGridDom(dom, options, targetEvents, { boc, eoc })
     if (options.displayLegend) displayLegend(dom, targetEvents, options)
     if (options.customHeader) customHeaderDom(dom, options, { boc, eoc })

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ All the properties are omittable, and if omitted, a default value will be applie
 |`customHeader` | false | See `customHeader` section.
 |`headerTitleOptions`|{month: 'long'} | The format of header of the view. It varies by the `locale` and this option. <br> `locale:'en-US'`, the default displaying will be `December`. See `customHeader` section. (Since 1.9.0, behaviour changed.) |
 |`maxEventLines` | 5 | How many events will be displayed in 1-day cell. The overflowed events will be hidden. <br> (Since 1.9.0) This value could be an array or an object define multi value for week the rows of the calendar. See the `dynamic eventlines` part.|
+|`showHeader` | true | If set `false`, the headers are disabled. Useful if have two instances running with one above the other to not have the headers repeat. |
 
 
 ## Notification


### PR DESCRIPTION
Default is true.

When set to false, the headers are surpressed. This is of use when have two instances enabled one above the other to not have the headers repeat in the second instance.