### PR TITLE
Fix overflow icon number positioning

### DIFF
--- a/MMM-CalendarExt3.css
+++ b/MMM-CalendarExt3.css
@@ -105,6 +105,7 @@ selector-pseudo-class-no-unknown, keyframes-name-pattern,
   background-color: white;
   z-index: 30;
   text-overflow: "+";
+  line-height: 18px;
 }
 
 .CX3 .cellHeader {


### PR DESCRIPTION
Before, the number showing how many more items there are for days that have too many events was positioned incorrectly. This fixes it and centers it in the little dot.