### PR TITLE
fix: update calendar on event notifications

### DIFF
--- a/MMM-CalendarExt3.js
+++ b/MMM-CalendarExt3.js
@@ -378,6 +378,7 @@ Module.register("MMM-CalendarExt3", {
     if (notification === this.notifications.eventNotification) {
       const convertedPayload = this.notifications.eventPayload(payload)
       this.eventPool.set(sender.identifier, structuredClone(convertedPayload))
+      this.updateAnimate()
     }
 
     if (notification === "MODULE_DOM_CREATED") {


### PR DESCRIPTION
Hi devs, thanks for such a great module!

This PR just adds one line of code, line 381 below, to MMM-CalendarExt3.js:

```
378-    if (notification === this.notifications.eventNotification) {
379-      const convertedPayload = this.notifications.eventPayload(payload)
380-      this.eventPool.set(sender.identifier, structuredClone(convertedPayload))
381:      this.updateAnimate()
382-    }
```

This makes it such that, when an eventNotification is received, the calendar refreshes (animates in and out) with the new events.

For my use case, the simplest thing was to make the refresh unconditional: every eventNotification triggers an updateAnimate call, and there's no way to stop it. But, if preferred, I'd be happy to gate the updateAnimate call in some sort of clause. It could be a config parameter that the user sets, or a parameter that's passed as part of the notification payload. In either case, we could preserve the existing default behavior if that is preferable.